### PR TITLE
Fix engine to be consistent with Stockfish up to a depth of 7

### DIFF
--- a/src/include/Constants.hpp
+++ b/src/include/Constants.hpp
@@ -170,9 +170,9 @@ constexpr U64 south_west(U64 b) { return (b & ~FILE_A) >> 7; };
 constexpr U64 north_west(U64 b) { return (b & ~FILE_A) << 9; };
 
 const U64 KING_SIDE_CASTLING_MASK_WHITE = RANK_1 & (FILE_F | FILE_G);
-const U64 QUEEN_SIDE_CASTLING_MASK_WHITE = RANK_1 & (FILE_C | FILE_D);
+const U64 QUEEN_SIDE_CASTLING_MASK_WHITE = RANK_1 & (FILE_C | FILE_D | FILE_B);
 const U64 KING_SIDE_CASTLING_MASK_BLACK = RANK_8 & (FILE_F | FILE_G);
-const U64 QUEEN_SIDE_CASTLING_MASK_BLACK = RANK_8 & (FILE_C | FILE_D);
+const U64 QUEEN_SIDE_CASTLING_MASK_BLACK = RANK_8 & (FILE_C | FILE_D | FILE_B);
 
 inline int CountSetBits(U64 number) {
     int count = 0;

--- a/src/include/Test.hpp
+++ b/src/include/Test.hpp
@@ -28,7 +28,7 @@ class Test {
          *
          * If operating with useGUI on then each move will be made the GUI updated and the loop paused until the user enters N in the console ("next") thereby checking each moves validity slowly.
         */
-        unsigned long int MoveGeneration(int depth, bool useGUI);
+        unsigned long int MoveGeneration(int depth);
         /**
          * @brief Get the number of moves that are possible from the start position up to a speicifed depth (values from Stockfish 16)
         */

--- a/src/include/Test.hpp
+++ b/src/include/Test.hpp
@@ -31,7 +31,9 @@ class Test {
         unsigned long int MoveGeneration(int depth, bool useGUI);
         unsigned long int GetExpectedGeneration(int depth) { return depth < fExpectedGeneration.size() ? fExpectedGeneration[depth] : 0; };
         const std::unique_ptr<Board>& GetBoard() { return fBoard; };
+        void SetPrintDepth(int depth) { fPrintDepth = depth; };
     private:
+        int fPrintDepth;
         std::unique_ptr<Board> fBoard;
         std::unique_ptr<Engine> fEngine;
         std::unique_ptr<Renderer> fGUI;

--- a/src/include/Test.hpp
+++ b/src/include/Test.hpp
@@ -29,6 +29,9 @@ class Test {
          * If operating with useGUI on then each move will be made the GUI updated and the loop paused until the user enters N in the console ("next") thereby checking each moves validity slowly.
         */
         unsigned long int MoveGeneration(int depth, bool useGUI);
+        /**
+         * @brief Get the number of moves that are possible from the start position up to a speicifed depth (values from Stockfish 16)
+        */
         unsigned long int GetExpectedGeneration(int depth) { return depth < fExpectedGeneration.size() ? fExpectedGeneration[depth] : 0; };
         const std::unique_ptr<Board>& GetBoard() { return fBoard; };
         void SetPrintDepth(int depth) { fPrintDepth = depth; };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,10 +11,31 @@ int main() {
     Test t = Test();
 
     //U32 move = 0;
-    //SetMove(move, RANK_2 & FILE_A, RANK_3 & FILE_A, Piece::Pawn, Piece::Null);
+    //SetMove(move, RANK_2 & FILE_G, RANK_3 & FILE_G, Piece::Pawn, Piece::Null);
+    //t.GetBoard()->MakeMove(move);
+
+    //move = 0;
+    //SetMove(move, RANK_7 & FILE_G, RANK_6 & FILE_G, Piece::Pawn, Piece::Null);
+    //t.GetBoard()->MakeMove(move);
+
+    //move = 0;
+    //SetMove(move, RANK_1 & FILE_G, RANK_3 & FILE_H, Piece::Knight, Piece::Null);
+    //t.GetBoard()->MakeMove(move);
+
+    //move = 0;
+    //SetMove(move, RANK_8 & FILE_F, RANK_6 & FILE_H, Piece::Bishop, Piece::Null);
+    //t.GetBoard()->MakeMove(move);
+
+    //move = 0;
+    //SetMove(move, RANK_1 & FILE_F, RANK_2 & FILE_G, Piece::Bishop, Piece::Null);
+    //t.GetBoard()->MakeMove(move);
+
+    //move = 0;
+    //SetMove(move, RANK_6 & FILE_H, RANK_2 & FILE_D, Piece::Bishop, Piece::Null);
     //t.GetBoard()->MakeMove(move);
 
     int depth = 7;
+    t.SetPrintDepth(depth);
     unsigned long int nMoves = t.MoveGeneration(depth, false);
     std::cout << "Number of generated moves after depth " << depth << " = " << nMoves << " (correct = " << t.GetExpectedGeneration(depth) << ")\n";
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,32 +11,38 @@ int main() {
     Test t = Test();
 
     //U32 move = 0;
-    //SetMove(move, RANK_2 & FILE_G, RANK_3 & FILE_G, Piece::Pawn, Piece::Null);
+    //SetMove(move, RANK_2 & FILE_E, RANK_4 & FILE_E, Piece::Pawn, Piece::Null);
     //t.GetBoard()->MakeMove(move);
 
     //move = 0;
-    //SetMove(move, RANK_7 & FILE_G, RANK_6 & FILE_G, Piece::Pawn, Piece::Null);
+    //SetMove(move, RANK_7 & FILE_D, RANK_5 & FILE_D, Piece::Pawn, Piece::Null);
     //t.GetBoard()->MakeMove(move);
 
     //move = 0;
-    //SetMove(move, RANK_1 & FILE_G, RANK_3 & FILE_H, Piece::Knight, Piece::Null);
+    //SetMove(move, RANK_1 & FILE_D, RANK_2 & FILE_E, Piece::Queen, Piece::Null);
     //t.GetBoard()->MakeMove(move);
 
     //move = 0;
-    //SetMove(move, RANK_8 & FILE_F, RANK_6 & FILE_H, Piece::Bishop, Piece::Null);
+    //SetMove(move, RANK_5 & FILE_D, RANK_4 & FILE_E, Piece::Pawn, Piece::Null);
+    //SetMoveTakenPiece(move, Piece::Pawn);
+    //SetMovePieceWasTaken(move, true);
     //t.GetBoard()->MakeMove(move);
 
     //move = 0;
-    //SetMove(move, RANK_1 & FILE_F, RANK_2 & FILE_G, Piece::Bishop, Piece::Null);
+    //SetMove(move, RANK_1 & FILE_E, RANK_1 & FILE_D, Piece::King, Piece::Null);
+    //t.GetBoard()->MakeMove(move);
+
+    //move = 0;
+    //SetMove(move, RANK_8 & FILE_C, RANK_4 & FILE_G, Piece::Bishop, Piece::Null);
     //t.GetBoard()->MakeMove(move);
 
     //move = 0;
     //SetMove(move, RANK_6 & FILE_H, RANK_2 & FILE_D, Piece::Bishop, Piece::Null);
     //t.GetBoard()->MakeMove(move);
 
-    int depth = 7;
+    int depth = 6;
     t.SetPrintDepth(depth);
-    unsigned long int nMoves = t.MoveGeneration(depth, false);
+    unsigned long int nMoves = t.MoveGeneration(depth);
     std::cout << "Number of generated moves after depth " << depth << " = " << nMoves << " (correct = " << t.GetExpectedGeneration(depth) << ")\n";
 
 

--- a/src/src/Engine.cpp
+++ b/src/src/Engine.cpp
@@ -136,14 +136,19 @@ void Engine::PruneCheckMoves(const std::unique_ptr<Board> &board) {
     // TODO: Make this quicker i.e. don't make/undo every move as that is slow
     for(int iMove = 0; iMove < fLegalMoves.size(); iMove++) {
         U32 move = fLegalMoves[iMove];
-        board->MakeMove(move);
-        U64 underAttack = GetAttacks(board, board->GetColorToMove());
-        U64 king = board->GetBoard(board->GetColorToMove() == Color::White ? Color::Black : Color::White, Piece::King);
-        if(underAttack & king) { // Move was illegal so remove it
+        if(GetMoveIsCastling(move)) {
             fLegalMoves.erase(std::begin(fLegalMoves) + iMove);
             iMove--;
+        } else {
+            board->MakeMove(move);
+            U64 underAttack = GetAttacks(board, board->GetColorToMove());
+            U64 king = board->GetBoard(board->GetColorToMove() == Color::White ? Color::Black : Color::White, Piece::King);
+            if(underAttack & king) { // Move was illegal so remove it
+                fLegalMoves.erase(std::begin(fLegalMoves) + iMove);
+                iMove--;
+            }
+            board->UndoMove();
         }
-        board->UndoMove();
     }
 }
 

--- a/src/src/Test.cpp
+++ b/src/src/Test.cpp
@@ -20,78 +20,36 @@ Test::Test() {
     };
 }
 
-unsigned long int Test::MoveGeneration(int depth, bool useGUI) {
-    if(useGUI) {
-        while(fGUI->GetWindowIsOpen()) {
+unsigned long int Test::MoveGeneration(int depth) {
+    if(depth == 0)
+        return 1;
 
-            unsigned long int numPositions = 0;
-            if(depth == 0)
-                return 1;
+    fEngine->GenerateLegalMoves(fBoard);
+    unsigned long int numPositions = 0;
+    unsigned long int subPositions = 0;
 
-            fEngine->GenerateLegalMoves(fBoard);
-            std::string uIn = "";
-            std::vector<U32> moves = fEngine->GetLegalMoves();
+    std::vector<U32> moves = fEngine->GetLegalMoves();
+    if(depth == fPrintDepth)
+        std::cout << "Parent nodes to search = " << moves.size() << "\n";
 
-            for(int iMove = 0; iMove < moves.size(); iMove++) {
-                U32 move = moves.at(iMove);
-
-                if(depth == 1) {
-                    while(uIn.compare("n")) {
-                        std::cout << "Awaiting 'n' command to continue: ";
-                        std::getline(std::cin, uIn);
-                    }
-                }
-
-                if(depth == 2) {
-
-                }
-
-                fBoard->MakeMove(move);
-
-                //std::cout << "Depth = " << 4 - depth << " Nodes = " << numPositions << " ";
-                //PrintMove(move);
-                fGUI->Update(fBoard);
-
-                
-
-                numPositions += MoveGeneration(depth - 1, true);
-                fBoard->UndoMove();
-            }
-            return numPositions;
-        }
-    } else {
-        if(depth == 0)
-            return 1;
-
-        fEngine->GenerateLegalMoves(fBoard);
-        unsigned long int numPositions = 0;
-        unsigned long int subPositions = 0;
-
-        std::vector<U32> moves = fEngine->GetLegalMoves();
-        if(depth == fPrintDepth)
-            std::cout << "Parent nodes to search = " << moves.size() << "\n";
-
-        for(int iMove = 0; iMove < moves.size(); iMove++) {
-            U32 move = moves.at(iMove);
-            if(depth == fPrintDepth) {
-                PrintMove(move); 
-                subPositions = numPositions;
-            }
-
-            //if(depth == 1) {
-            //    std::cout << "\n depth 1 move = ";
-            //    PrintMove(move);
-            //}
-            fBoard->MakeMove(move);
-            numPositions += MoveGeneration(depth - 1, false);
-            if(depth == fPrintDepth) {
-                std::cout << ": " << numPositions - subPositions << "\n";
-            }
-            fBoard->UndoMove();
+    for(int iMove = 0; iMove < moves.size(); iMove++) {
+        U32 move = moves.at(iMove);
+        if(depth == fPrintDepth) {
+            PrintMove(move); 
+            subPositions = numPositions;
         }
 
-        return numPositions;
+        //if(depth == 1) {
+        //    std::cout << "\n depth 1 move = ";
+        //    PrintMove(move);
+        //}
+        fBoard->MakeMove(move);
+        numPositions += MoveGeneration(depth - 1);
+        if(depth == fPrintDepth) {
+            std::cout << ": " << numPositions - subPositions << "\n";
+        }
+        fBoard->UndoMove();
     }
 
-    return -1;
+    return numPositions;
 }

--- a/src/src/Test.cpp
+++ b/src/src/Test.cpp
@@ -4,6 +4,7 @@ Test::Test() {
     fBoard = std::make_unique<Board>();
     fEngine = std::make_unique<Engine>(true);
     fGUI = std::make_unique<Renderer>();
+    fPrintDepth = 999;
 
     fExpectedGeneration = {
         1,
@@ -66,15 +67,13 @@ unsigned long int Test::MoveGeneration(int depth, bool useGUI) {
         unsigned long int numPositions = 0;
         unsigned long int subPositions = 0;
 
-        const int printDepth = 7;
-
         std::vector<U32> moves = fEngine->GetLegalMoves();
-        if(depth == printDepth)
+        if(depth == fPrintDepth)
             std::cout << "Parent nodes to search = " << moves.size() << "\n";
 
         for(int iMove = 0; iMove < moves.size(); iMove++) {
             U32 move = moves.at(iMove);
-            if(depth == printDepth) {
+            if(depth == fPrintDepth) {
                 PrintMove(move); 
                 subPositions = numPositions;
             }
@@ -85,7 +84,7 @@ unsigned long int Test::MoveGeneration(int depth, bool useGUI) {
             //}
             fBoard->MakeMove(move);
             numPositions += MoveGeneration(depth - 1, false);
-            if(depth == printDepth) {
+            if(depth == fPrintDepth) {
                 std::cout << ": " << numPositions - subPositions << "\n";
             }
             fBoard->UndoMove();


### PR DESCRIPTION
Various bug fixes to ensure consistency of my engine against the test engine (Stockfish 16) up to a depth of 7 from the standard chess board starting position. Bugs patched included:

1. Fix queenside castling mask to include B-file
2. Fix absolute pinning calculation (resetting isLegal by accident)
3. Prevent castling moves when in check

See results from the Perft(7) test below:
**My Engine:**
h2h3: 106678423
h2h4: 138495290
g2g3: 135987651
g2g4: 130293018
f2f3: 102021008
f2f4: 119614841
e2e3: 306138410
e2e4: 309478263
d2d3: 227598692
d2d4: 269605599
c2c3: 144074944
c2c4: 157756443
b2b3: 133233975
b2b4: 134087476
a2a3: 106743106
a2a4: 137077337
g1h3: 120669525
g1f3: 147678554
b1c3: 148527161
b1a3: 120142144

**Stockfish:**
a2a3: 106743106
b2b3: 133233975
c2c3: 144074944
d2d3: 227598692
e2e3: 306138410
f2f3: 102021008
g2g3: 135987651
h2h3: 106678423
a2a4: 137077337
b2b4: 134087476
c2c4: 157756443
d2d4: 269605599
e2e4: 309478263
f2f4: 119614841
g2g4: 130293018
h2h4: 138495290
b1a3: 120142144
b1c3: 148527161
g1f3: 147678554
g1h3: 120669525