### PR TITLE
Minor performance improvement in move generation

### DIFF
--- a/src/include/Board.hpp
+++ b/src/include/Board.hpp
@@ -95,7 +95,13 @@ class Board {
         */
         std::pair<Color, Piece> GetIsOccupied(const U64 pos);
         /**
-            * @brief Get the number of completed moves full moves (e.g. both black and white have had a turn)
+        * @brief Get the Color and type of piece (if any) occupying the position
+        * @param pos The position on the board to check
+        * @return The color and piece of the occupying piece (if any) else Null piece is given.
+       */
+       std::pair<Color, Piece> GetIsOccupied(const U64 pos, const Color color);
+        /**
+        * @brief Get the number of completed moves full moves (e.g. both black and white have had a turn)
         */
         int GetNMovesMade() { return (int)(fMadeMoves.size() / 2); };
         /**

--- a/src/include/Constants.hpp
+++ b/src/include/Constants.hpp
@@ -117,7 +117,6 @@ inline U64 hypQuint(U64 piece, U64 occupancy, U64 mask) {
     return (((mask & occupancy) - piece * 2) ^ reverse(reverse(mask & occupancy) - reverse(piece) * 2)) & mask;
 }
 
-// TODO: Delete me this is for testing only
 inline int PrintBitset(U64 b) {
     std::bitset<64> x = b;
     std::string s = x.to_string();

--- a/src/include/Constants.hpp
+++ b/src/include/Constants.hpp
@@ -151,6 +151,20 @@ constexpr U64 FILE_H = 0x0101010101010101ULL;
 constexpr U64 FILE_GH = FILE_G | FILE_H;
 constexpr U64 FILE_AB = FILE_A | FILE_B;
 
+// For faster castling calculations
+constexpr U64 SQUARE_H1 = FILE_H & RANK_1;
+constexpr U64 SQUARE_F1 = FILE_F & RANK_1;
+constexpr U64 SQUARE_G1 = FILE_G & RANK_1;
+constexpr U64 SQUARE_C1 = FILE_C & RANK_1;
+constexpr U64 SQUARE_A1 = FILE_A & RANK_1;
+constexpr U64 SQUARE_D1 = FILE_D & RANK_1;
+constexpr U64 SQUARE_H8 = FILE_H & RANK_8;
+constexpr U64 SQUARE_F8 = FILE_F & RANK_8;
+constexpr U64 SQUARE_A8 = FILE_A & RANK_8;
+constexpr U64 SQUARE_D8 = FILE_D & RANK_8;
+constexpr U64 SQUARE_G8 = FILE_G & RANK_8;
+constexpr U64 SQUARE_C8 = FILE_C & RANK_8;
+
 const U64 WHITE_SQUARES = (FILE_A & (RANK_2 | RANK_4 | RANK_6 | RANK_8)) |
                             (FILE_B & (RANK_1 | RANK_3 | RANK_5 | RANK_7)) |
                             (FILE_C & (RANK_2 | RANK_4 | RANK_6 | RANK_8)) |

--- a/src/include/Engine.hpp
+++ b/src/include/Engine.hpp
@@ -181,11 +181,11 @@ class Engine {
         /**
          * @brief Determines if castling is possible on a particular side on the current board. 
         */
-        bool IsCastlingPossible(U64 castlingMask, U64 occupancyMask, const std::unique_ptr<Board> &board);
+        bool IsCastlingPossible(const U64 castlingMask, const U64 occupancyMask, const std::unique_ptr<Board> &board);
         /**
          * @brief True if any of the positions in mask and attacked by the specified colour on the current board.
         */
-        bool IsUnderAttack(U64 mask, Color attackingColor, const std::unique_ptr<Board> &board);
+        bool IsUnderAttack(const U64 mask, const Color attackingColor, const std::unique_ptr<Board> &board);
 };
 
 #endif

--- a/src/include/Engine.hpp
+++ b/src/include/Engine.hpp
@@ -63,11 +63,11 @@ class Engine {
         /**
          * @brief Check the board to see if the 50 move rule draw has been met. Update internal board state to match.
         */
-        void CheckFiftyMoveDraw(const std::unique_ptr<Board> &board);
+        bool CheckFiftyMoveDraw(const std::unique_ptr<Board> &board);
         /**
          * @brief Check the board for a draw by insufficient material. Updates internal board state to match.
         */
-        void CheckInsufficientMaterial(const std::unique_ptr<Board> &board);
+        bool CheckInsufficientMaterial(const std::unique_ptr<Board> &board);
 
         float Evaluate(Board board); // Static evaluation of current game state with no look-ahead
         void SetMaxDepth(int depth) { fMaxDepth = depth; };

--- a/src/include/Test.hpp
+++ b/src/include/Test.hpp
@@ -23,7 +23,7 @@
  */ 
 class Test {
     public:
-        explicit Test();
+        explicit Test(bool useGUI);
         /**
          * @brief Generate the number of moves possible up to the specified depth. Can compare with literature (fExpectedGeneration).
          *
@@ -49,7 +49,6 @@ class Test {
         /**
          * @brief Set whether to display the GUI
         */
-       void SetUseGUI(bool useGUI) { fUseGUI = useGUI; };
     private:
         bool fUseGUI; ///< If true display GUI to user when performing the tests
         int fPrintDepth;

--- a/src/include/Test.hpp
+++ b/src/include/Test.hpp
@@ -8,6 +8,7 @@
 #define TEST_HPP
 
 #include <vector>
+#include <chrono>
 
 #include "Constants.hpp"
 #include "Move.hpp"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -133,8 +133,7 @@ int main(int argc, char* argv[]) {
     if(helpRequested) {
         DisplayHelp();
     } else if(perftDepth > 0) {
-        Test myTest = Test();
-        myTest.SetUseGUI(useGUI);
+        Test myTest = Test(useGUI);
         unsigned long int result = myTest.GetNodes(perftDepth, fenString);
         std::cout << "\nNodes searched: " << result << "\n";
     } else if(doGame) {

--- a/src/src/Board.cpp
+++ b/src/src/Board.cpp
@@ -350,3 +350,16 @@ std::pair<Color, Piece> Board::GetIsOccupied(const U64 pos) {
     }
     return std::make_pair(Color::White, Piece::Null);
 }
+
+std::pair<Color, Piece> Board::GetIsOccupied(const U64 pos, const Color color) {
+    // Similar to GetIsOccupied(pos) but only searches the boards of the provided color
+    uint8_t offset = color == Color::White ? 0 : 6;
+    for (int iBoard = offset; iBoard < offset + 6; iBoard++) {
+        if(pos & fBoards[iBoard]) {
+            uint8_t pieceIndex = iBoard >= 6 ? iBoard - 5 : iBoard + 1; // Must fall in range 1--6 (inclusive)
+            Piece pieceType = static_cast<Piece>(pieceIndex);
+            return std::make_pair(color, pieceType);
+        }
+    }
+    return std::make_pair(color, Piece::Null);
+}

--- a/src/src/Board.cpp
+++ b/src/src/Board.cpp
@@ -245,8 +245,11 @@ U64* Board::GetBoardPointer(const Color color, const Piece piece) {
 }
 
 void Board::SetBoard(const Color color, const Piece piece, const U64 board) {
-    uint8_t offset = color == Color::White ? -1 : 5;
-    fBoards[(int)piece + offset] = board;
+    if(color == Color::White) {
+        fBoards[(int)piece - 1] = board;
+    } else {
+        fBoards[(int)piece + 5] = board;
+    }
 }
 
 void Board::EmptyBoards() {

--- a/src/src/Board.cpp
+++ b/src/src/Board.cpp
@@ -348,27 +348,11 @@ void Board::LoadFEN(const std::string &fen) {
 }
 
 std::pair<Color, Piece> Board::GetIsOccupied(const U64 pos) {
-    for(int iBoard = 0; iBoard < 12; iBoard++) {
+    for (int iBoard = 0; iBoard < 12; iBoard++) {
         if(pos & fBoards[iBoard]) {
-            // We already know the mapping e.g. pawn, knight, bishop, rook, queen, king (white, black)
-            Piece pieceType = Piece::Null;
-            int x = iBoard;
-            if(iBoard >= 6)
-                x = iBoard - 6;
-
-            if(x == 0) {
-                pieceType = Piece::Pawn;
-            } else if(x == 1) {
-                pieceType = Piece::Bishop;
-            } else if(x == 2) {
-                pieceType = Piece::Knight;
-            } else if(x == 3) {
-                pieceType = Piece::Rook;
-            } else if(x == 4) {
-                pieceType = Piece::Queen;
-            } else if(x == 5) {
-                pieceType = Piece::King;
-            }
+            // We already know the mapping e.g. 0 = pawn, knight, bishop, rook, queen, king (white, black)
+            uint8_t pieceIndex = iBoard >= 6 ? iBoard - 5 : iBoard + 1; // Must fall in range 0--6 (inclusive)
+            Piece pieceType = static_cast<Piece>(pieceIndex);
             return std::make_pair(iBoard < 6 ? Color::White : Color::Black, pieceType);
         }
     }

--- a/src/src/Engine.cpp
+++ b/src/src/Engine.cpp
@@ -372,6 +372,7 @@ void Engine::GenerateEnPassantMoves(const std::unique_ptr<Board> &board) {
 
     // Now run the usual code
     U32 lastMove = board->GetLastMove();
+    U64 lastMoveTarget = GetMoveTarget(lastMove);
 
     // Faster return if you know en-passant will not be possible
     if(GetMovePiece(lastMove) != Piece::Pawn || GetMoveIsEnPassant(lastMove) || GetMoveIsCastling(lastMove))
@@ -380,13 +381,13 @@ void Engine::GenerateEnPassantMoves(const std::unique_ptr<Board> &board) {
     U64 pawns = board->GetBoard(board->GetColorToMove(), Piece::Pawn);
     U64 enPassantPawns = 0;
 
-    if(board->GetColorToMove() == Color::White && (GetMoveOrigin(lastMove) & RANK_7) && (GetMoveTarget(lastMove) & RANK_5)) {
+    if(board->GetColorToMove() == Color::White && (GetMoveOrigin(lastMove) & RANK_7) && (lastMoveTarget & RANK_5)) {
         // Was a double-move forward with a pawn by black last turn
         // Check if the move placed the pawn on an adjacent file to any of your pawns on rank 5
-        enPassantPawns = (east(GetMoveTarget(lastMove)) | west(GetMoveTarget(lastMove))) & pawns;
-    } else if(board->GetColorToMove() == Color::Black && (GetMoveOrigin(lastMove) & RANK_2) && (GetMoveTarget(lastMove) & RANK_4)) {
+        enPassantPawns = (east(lastMoveTarget) | west(lastMoveTarget)) & pawns;
+    } else if(board->GetColorToMove() == Color::Black && (GetMoveOrigin(lastMove) & RANK_2) && (lastMoveTarget & RANK_4)) {
         // Was a double-move forward with a pawn by white last turn
-        enPassantPawns = (east(GetMoveTarget(lastMove)) | west(GetMoveTarget(lastMove))) & pawns;
+        enPassantPawns = (east(lastMoveTarget) | west(lastMoveTarget)) & pawns;
     }
     while(enPassantPawns) {
         U64 pawn = 0;
@@ -395,7 +396,7 @@ void Engine::GenerateEnPassantMoves(const std::unique_ptr<Board> &board) {
         SetMove(
             move, 
             pawn, 
-            board->GetColorToMove() == Color::White ? north(GetMoveTarget(lastMove)) : south(GetMoveTarget(lastMove)), Piece::Pawn, 
+            board->GetColorToMove() == Color::White ? north(lastMoveTarget) : south(lastMoveTarget), Piece::Pawn, 
             Piece::Pawn
         );
         SetMoveIsEnPassant(move, true);
@@ -416,14 +417,14 @@ void Engine::GenerateCastlingMoves(const std::unique_ptr<Board> &board) {
         if(!board->GetWhiteKingsideRookMoved() && 
             IsCastlingPossible(KING_SIDE_CASTLING_MASK_WHITE, KING_SIDE_CASTLING_OCCUPANCY_MASK_WHITE, board)) 
         {
-            SetMove(move, origin, RANK_1 & FILE_G, Piece::King, Piece::Null);
+            SetMove(move, origin, SQUARE_G1, Piece::King, Piece::Null);
             SetMoveIsCastling(move, true);
             fLegalMoves.push_back(move);
             move = 0;
         }
         if(!board->GetWhiteQueensideRookMoved() &&
             IsCastlingPossible(QUEEN_SIDE_CASTLING_MASK_WHITE, QUEEN_SIDE_CASTLING_OCCUPANCY_MASK_WHITE, board)) {
-            SetMove(move, origin, RANK_1 & FILE_C, Piece::King, Piece::Null);
+            SetMove(move, origin, SQUARE_C1, Piece::King, Piece::Null);
             SetMoveIsCastling(move, true);
             fLegalMoves.push_back(move);
             move = 0;
@@ -433,7 +434,7 @@ void Engine::GenerateCastlingMoves(const std::unique_ptr<Board> &board) {
         if (!board->GetBlackKingsideRookMoved() &&
             IsCastlingPossible(KING_SIDE_CASTLING_MASK_BLACK, KING_SIDE_CASTLING_OCCUPANCY_MASK_BLACK, board)) 
         {
-            SetMove(move, origin, RANK_8 & FILE_G, Piece::King, Piece::Null);
+            SetMove(move, origin, SQUARE_G8, Piece::King, Piece::Null);
             SetMoveIsCastling(move, true);
             fLegalMoves.push_back(move);
             move = 0;
@@ -441,7 +442,7 @@ void Engine::GenerateCastlingMoves(const std::unique_ptr<Board> &board) {
         if (!board->GetBlackQueensideRookMoved() &&
             IsCastlingPossible(QUEEN_SIDE_CASTLING_MASK_BLACK, QUEEN_SIDE_CASTLING_OCCUPANCY_MASK_BLACK, board)) 
         {
-            SetMove(move, origin, RANK_8 & FILE_C, Piece::King, Piece::Null);
+            SetMove(move, origin, SQUARE_C8, Piece::King, Piece::Null);
             SetMoveIsCastling(move, true);
             fLegalMoves.push_back(move);
             move = 0;

--- a/src/src/Engine.cpp
+++ b/src/src/Engine.cpp
@@ -114,21 +114,24 @@ void Engine::GenerateLegalMoves(const std::unique_ptr<Board> &board) {
 }
 
 void Engine::UpdatePromotionMoves() {
-    std::vector<U32> promoMoves = {};
+    std::vector<U32> promoMoves;
     const std::vector<Piece> promoPieces = {Piece::Bishop, Piece::Knight, Piece::Rook, Piece::Queen};
-    for(int iMove = 0; iMove < fLegalMoves.size(); iMove++) {
-        U32 move = fLegalMoves[iMove];
-        if(!GetMoveIsPromotion(move))
+    for (auto it = fLegalMoves.begin(); it != fLegalMoves.end(); ) {
+        U32 move = *it;
+        if (!GetMoveIsPromotion(move)) {
+            ++it;
             continue;
-        fLegalMoves.erase(std::begin(fLegalMoves) + iMove); // Remove the current promotion move with no defined promo piece
-        // Add a unique move for all 4 promotion types (rook, knight, queen and bishop promotions)
+        }
+        // Use the erase-remove idiom to efficiently remove elements
+        it = fLegalMoves.erase(it);
+        // Add a unique move for all 4 promotion types
         for (Piece promotionPiece : promoPieces) {
             U32 promotionMove = move;
             SetMovePromotionPiece(promotionMove, promotionPiece);
             promoMoves.push_back(promotionMove);
         }
-        iMove--;
     }
+    // Append promoMoves to fLegalMoves
     fLegalMoves.insert(fLegalMoves.end(), promoMoves.begin(), promoMoves.end());
 }
 

--- a/src/src/Engine.cpp
+++ b/src/src/Engine.cpp
@@ -165,7 +165,7 @@ void Engine::StripIllegalMoves(const std::unique_ptr<Board> &board) {
             iMove--;
         // Absolutely pinned pieces may not move, unless it is a capture of that piece or along pinning ray
         } else if(pinnedPositions & moveOrigin) { // Piece originates from a pinned position
-            for(auto pins : pinnedPieces) {
+            for(const std::pair<U64, U64> pins : pinnedPieces) {
                 // !Piece moving from pinned position to somewhere on the associated pinning ray (incl capture)
                 if((moveOrigin & pins.first) && (GetMoveTarget(m) & ~pins.second)) {
                     // Moving to somewhere off the absolutely pinning ray (illegal)

--- a/src/src/Test.cpp
+++ b/src/src/Test.cpp
@@ -22,6 +22,7 @@ Test::Test() {
 }
 
 unsigned long int Test::GetNodes(int depth, std::string fen) {
+    auto start = std::chrono::high_resolution_clock::now(); // Time the execution
     if(fen.length() > 0)
         fBoard->LoadFEN(fen);
     SetPrintDepth(depth);
@@ -38,7 +39,11 @@ unsigned long int Test::GetNodes(int depth, std::string fen) {
             }
         } // User closing the window means they are "happy" with the position
     }
-    return MoveGeneration(depth);
+    unsigned long moves = MoveGeneration(depth);
+    auto stop = std::chrono::high_resolution_clock::now();
+    auto duration = duration_cast<std::chrono::microseconds>(stop - start);
+    std::cout << "Searched complete node tree in " << duration.count() << " microseconds\n";
+    return moves;
 }
 
 unsigned long int Test::MoveGeneration(int depth) {

--- a/src/src/Test.cpp
+++ b/src/src/Test.cpp
@@ -1,10 +1,12 @@
 #include "Test.hpp"
 
-Test::Test() {
+Test::Test(bool useGUI) {
     fBoard = std::make_unique<Board>();
     fEngine = std::make_unique<Engine>(true);
     fGUI = std::make_unique<Renderer>();
-    fUseGUI = true;
+    fUseGUI = useGUI;
+    if(!fUseGUI)
+        fGUI->CloseWindow();
     fPrintDepth = 999;
 
     fExpectedGeneration = {


### PR DESCRIPTION
Use constexpr where possible and use smarter for looping logic as well as algorithms from the numeric library to speed up computation slightly when generating moves.