### PR TITLE
Move move generation into a separate Generator class

### DIFF
--- a/FindPerftDiff.py
+++ b/FindPerftDiff.py
@@ -1,0 +1,38 @@
+import pandas as pd
+import numpy as np
+
+stockfish = pd.read_csv("./perft/fish3.txt", header=None, sep=":")
+stockfish.columns = ["InitialMove", "Nodes"]
+stockfish.set_index("InitialMove", inplace=True)
+
+generator = pd.read_csv("./perft/gen3.txt", header=None, sep=":")
+generator.columns = ["InitialMove", "Nodes"]
+generator.set_index("InitialMove", inplace=True)
+
+isDiff = False
+
+# Search for differences in the index
+missing_from_gen = [i for i in stockfish.index if i not in generator.index]
+if len(missing_from_gen) > 0:
+    print(f"Generator failed to find {len(missing_from_gen)} initial nodes: ")
+    for nodeName in missing_from_gen:
+        isDiff = True
+        print(f"Missing a node: {nodeName}")
+    exit()
+
+# Search for differences in number of nodes after each initial move
+stockfish.sort_values('InitialMove', inplace=True)
+generator.sort_values('InitialMove', inplace=True)
+stockfish["NGen"] = generator["Nodes"]
+stockfish["Diff"] = stockfish["Nodes"] - stockfish["NGen"]
+
+for i, diff in enumerate(stockfish["Diff"].to_list()):
+    if diff != 0:
+        isDiff = True
+        if diff > 0:
+            print(f"Node {stockfish.index.to_list()[i]} has {abs(diff)} too few moves")
+        if diff < 0:
+            print(f"Node {stockfish.index.to_list()[i]} has {abs(diff)} too many moves")
+
+if not isDiff:
+    print("Results match")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,6 +12,7 @@ add_executable(ChessEngine
     main.cpp
     src/Board.cpp
     src/Engine.cpp
+    src/Generator.cpp
     src/Renderer.cpp
     src/Test.cpp
 )

--- a/src/include/Constants.hpp
+++ b/src/include/Constants.hpp
@@ -32,6 +32,8 @@ typedef unsigned long long U64;
  */
 typedef uint32_t U32;
 
+typedef uint8_t U8;
+
 /**
  * @brief Enumeration describing different piece colors.
  *
@@ -140,6 +142,7 @@ constexpr U64 RANK_5 = 0x000000FF00000000ULL;
 constexpr U64 RANK_6 = 0x0000FF0000000000ULL;
 constexpr U64 RANK_7 = 0x00FF000000000000ULL;
 constexpr U64 RANK_8 = 0xFF00000000000000ULL;
+const std::vector<U64> RANKS = {RANK_1, RANK_2, RANK_3, RANK_4, RANK_5, RANK_6, RANK_7, RANK_8};
 
 constexpr U64 FILE_A = 0x8080808080808080ULL;
 constexpr U64 FILE_B = 0x4040404040404040ULL;
@@ -149,6 +152,7 @@ constexpr U64 FILE_E = 0x0808080808080808ULL;
 constexpr U64 FILE_F = 0x0404040404040404ULL;
 constexpr U64 FILE_G = 0x0202020202020202ULL;
 constexpr U64 FILE_H = 0x0101010101010101ULL;
+const std::vector<U64> FILES = {FILE_A, FILE_B, FILE_C, FILE_D, FILE_E, FILE_F, FILE_G, FILE_H};
 constexpr U64 FILE_GH = FILE_G | FILE_H;
 constexpr U64 FILE_AB = FILE_A | FILE_B;
 
@@ -209,135 +213,31 @@ inline int CountSetBits(U64 number) {
 }
 
 inline U64 get_rank(U64 position) {
-    if(position & RANK_1) {
-        return RANK_1;
-    } else if(position & RANK_2) {
-        return RANK_2;
-    } else if(position & RANK_3) {
-        return RANK_3;
-    } else if(position & RANK_4) {
-        return RANK_4;
-    } else if(position & RANK_5) {
-        return RANK_5;
-    } else if(position & RANK_6) {
-        return RANK_6;
-    } else if(position & RANK_7) {
-        return RANK_7;
-    } else if(position & RANK_8) {
-        return RANK_8;
-    } else {
-        return 0;
-    }
+    U8 rankIndex = get_LSB(position) / 8;
+    return RANKS[rankIndex];
 }
 
 inline int get_rank_number(U64 position) {
-    if(position & RANK_1) {
-        return 1;
-    } else if(position & RANK_2) {
-        return 2;
-    } else if(position & RANK_3) {
-        return 3;
-    } else if(position & RANK_4) {
-        return 4;
-    } else if(position & RANK_5) {
-        return 5;
-    } else if(position & RANK_6) {
-        return 6;
-    } else if(position & RANK_7) {
-        return 7;
-    } else if(position & RANK_8) {
-        return 8;
-    } else {
-        return 0;
-    }
+    return (get_LSB(position) / 8) + 1; 
 }
 
 inline U64 get_file(U64 position) {
-    if(position & FILE_A) {
-        return FILE_A;
-    } else if(position & FILE_B) {
-        return FILE_B;
-    } else if(position & FILE_C) {
-        return FILE_C;
-    } else if(position & FILE_D) {
-        return FILE_D;
-    } else if(position & FILE_E) {
-        return FILE_E;
-    } else if(position & FILE_F) {
-        return FILE_F;
-    } else if(position & FILE_G) {
-        return FILE_G;
-    } else if(position & FILE_H) {
-        return FILE_H;
-    } else {
-        return 0;
-    }
+    U8 fileIndex = 7 - (get_LSB(position) % 8);
+    return FILES[fileIndex];
 }
 
 inline int get_file_number(U64 position) {
-    if(position & FILE_A) {
-        return 1;
-    } else if(position & FILE_B) {
-        return 2;
-    } else if(position & FILE_C) {
-        return 3;
-    } else if(position & FILE_D) {
-        return 4;
-    } else if(position & FILE_E) {
-        return 5;
-    } else if(position & FILE_F) {
-        return 6;
-    } else if(position & FILE_G) {
-        return 7;
-    } else if(position & FILE_H) {
-        return 8;
-    } else {
-        return 0;
-    }
+    return 8 - (get_LSB(position) % 8);
 }
 
 inline U64 get_rank_from_number(int n) {
-    if(n == 1) {
-        return RANK_1;
-    } else if(n == 2) {
-        return RANK_2;
-    } else if(n == 3) {
-        return RANK_3;
-    } else if(n == 4) {
-        return RANK_4;
-    } else if(n == 5) {
-        return RANK_5;
-    } else if(n == 6) {
-        return RANK_6;
-    } else if(n == 7) {
-        return RANK_7;
-    } else if(n == 8) {
-        return RANK_8;
-    } else {
-        return U64{0};
-    }
+    // Provide ranks as read from the board (1--8)
+    return RANKS[n - 1];
 }
 
 inline U64 get_file_from_number(int n) {
-    if(n == 1) {
-        return FILE_A;
-    } else if(n == 2) {
-        return FILE_B;
-    } else if(n == 3) {
-        return FILE_C;
-    } else if(n == 4) {
-        return FILE_D;
-    } else if(n == 5) {
-        return FILE_E;
-    } else if(n == 6) {
-        return FILE_F;
-    } else if(n == 7) {
-        return FILE_G;
-    } else if(n ==8) {
-        return FILE_H;
-    } else {
-        return U64{0};
-    }
+    // Provide file as read from board (A=1,B=2...)
+    return FILES[n - 1];
 }
 
 inline U64 get_file_from_char(char c) {

--- a/src/include/Constants.hpp
+++ b/src/include/Constants.hpp
@@ -18,8 +18,6 @@
 #define get_LSB(b) (__builtin_ctzll(b))
 #define get_MSB(b) (__builtin_clzll(b))
 
-constexpr U8 AVERAGE_MOVES_PER_POSITION{32};
-
 /**
  * @brief Typedef for U64 using unsigned long long.
  *
@@ -35,6 +33,8 @@ typedef unsigned long long U64;
 typedef uint32_t U32;
 
 typedef uint8_t U8;
+
+constexpr U8 AVERAGE_MOVES_PER_POSITION{32};
 
 /**
  * @brief Enumeration describing different piece colors.

--- a/src/include/Constants.hpp
+++ b/src/include/Constants.hpp
@@ -104,6 +104,7 @@ const float VALUE_QUEEN = 900.;
 const float VALUE_KING = 99999.;
 
 const float PIECE_VALUES[7] = {0., VALUE_PAWN, VALUE_BISHOP, VALUE_KNIGHT, VALUE_ROOK, VALUE_QUEEN, VALUE_KING};
+const std::vector<Piece> PROMOTION_PIECES = {Piece::Bishop, Piece::Knight, Piece::Rook, Piece::Queen};
 
 inline int pop_LSB(U64 &b) {
     int i = get_LSB(b);

--- a/src/include/Constants.hpp
+++ b/src/include/Constants.hpp
@@ -204,12 +204,7 @@ const U64 KING_SIDE_CASTLING_OCCUPANCY_MASK_BLACK = RANK_8 & (FILE_F | FILE_G);
 const U64 QUEEN_SIDE_CASTLING_OCCUPANCY_MASK_BLACK = RANK_8 & (FILE_C | FILE_D | FILE_B);
 
 inline int CountSetBits(U64 number) {
-    int count = 0;
-    while (number) {
-        count += number & 1;
-        number >>= 1;
-    }
-    return count;
+    return __builtin_popcountll(number);
 }
 
 inline U64 get_rank(U64 position) {

--- a/src/include/Constants.hpp
+++ b/src/include/Constants.hpp
@@ -18,6 +18,8 @@
 #define get_LSB(b) (__builtin_ctzll(b))
 #define get_MSB(b) (__builtin_clzll(b))
 
+constexpr U8 AVERAGE_MOVES_PER_POSITION{32};
+
 /**
  * @brief Typedef for U64 using unsigned long long.
  *

--- a/src/include/Generator.hpp
+++ b/src/include/Generator.hpp
@@ -9,6 +9,7 @@
 #include <memory>
 #include <vector>
 #include <chrono>
+#include <algorithm>
 
 #include "Constants.hpp"
 #include "Board.hpp"
@@ -90,6 +91,27 @@ class Generator {
          * @param board The board configuration to generate moves for.
         */
         void GeneratePseudoLegalMoves(const std::unique_ptr<Board> &board);
+        /**
+         * @brief Generate the pseudo-legal moves for the king.
+         * @param board The board configuration to generate moves for.
+        */
+        void GenerateKingPseudoLegalMoves(const std::unique_ptr<Board> &board);
+        /**
+         * @brief Generate the pseudo-legal moves for all the knights.
+         * @param board The board configuration to generate moves for.
+        */
+        void GenerateKnightPseudoLegalMoves(const std::unique_ptr<Board> &board);
+        /**
+         * @brief Generate the pseudo-legal moves for all the rooks.
+         * @param board The board configuration to generate moves for.
+        */
+        void GenerateRookPseudoLegalMoves(const std::unique_ptr<Board> &board);
+        /**
+         * @brief Generate the pseudo-legal moves for all the bishops.
+         * @param board The board configuration to generate moves for.
+        */
+        void GenerateBishopPseudoLegalMoves(const std::unique_ptr<Board> &board);
+
 
         // Attack tables generated on instantiation
         U64 fKnightAttacks[64]; ///< All possible attacks of a knight at each position on the board.

--- a/src/include/Generator.hpp
+++ b/src/include/Generator.hpp
@@ -111,7 +111,21 @@ class Generator {
          * @param board The board configuration to generate moves for.
         */
         void GenerateBishopPseudoLegalMoves(const std::unique_ptr<Board> &board);
-
+        /**
+         * @brief Generate the pseudo-legal moves for all the queens.
+         * @param board The board configuration to generate moves for.
+        */
+        void GenerateQueenPseudoLegalMoves(const std::unique_ptr<Board> &board);
+        /**
+         * @brief Generate the pseudo-legal moves for all the pawns.
+         * @param board The board configuration to generate moves for.
+        */
+        void GeneratePawnPseudoLegalMoves(const std::unique_ptr<Board> &board);
+        /**
+         * @brief Generate the set of possible castling moves.
+         * @param board The board configuration to generate moves for.
+        */
+        void GenerateCastlingMoves(const std::unique_ptr<Board> &board);
 
         // Attack tables generated on instantiation
         U64 fKnightAttacks[64]; ///< All possible attacks of a knight at each position on the board.
@@ -126,10 +140,10 @@ class Generator {
         U64 fBlackPawnForwardAttacks[64]; ///< Attacks (1 and 2 square forwards) of the black pawns
 
         // Variables to use when generating moves, helps reduce number of function calls
-        Color fColor;
-        Color fOtherColor;
-        U64 fOccupancy;
-        U64 fKing;
+        Color fColor; ///< The colour of the piece to move for the provided board configuration when generating legal moves is called.
+        Color fOtherColor; ///< The colour who has just moved.
+        U64 fOccupancy; ///< Total occupancy of the board represented as a single bitboard for ray occupancy calculations.
+        U64 fKing; ///< Position of the king whose colour it is to move.
         
 };
 

--- a/src/include/Generator.hpp
+++ b/src/include/Generator.hpp
@@ -154,6 +154,11 @@ class Generator {
          * @return Mask of all attacks by the attacking colour excluding absolute pins.
         */
         U64 GetAttacks(const std::unique_ptr<Board> &board, const Color attackingColor);
+        /**
+         * @brief Removes illegal moves from the fLegalMoves vector. Does a complete check such as with absolute pins etc.
+         * @param board The board configuration to generate moves for.
+        */
+        void RemoveIllegalMoves(const std::unique_ptr<Board> &board);
 
         // Attack tables generated on instantiation
         U64 fKnightAttacks[64]; ///< All possible attacks of a knight at each position on the board.

--- a/src/include/Generator.hpp
+++ b/src/include/Generator.hpp
@@ -36,7 +36,7 @@ class Generator {
          * @brief Get the legal moves from the last move generation.
          * @return Reference to the fLegalMoves vector.
         */
-        std::vector<U32>& GetLegalMoves() { return fLegalMoves; };
+        std::vector<U32> GetLegalMoves() { return fLegalMoves; };
         /**
          * @brief Get a copy of all the legal moves from the last move generation.
          * @return Vector of all possible legal moves, as a copy of the fLegalMoves vector.

--- a/src/include/Generator.hpp
+++ b/src/include/Generator.hpp
@@ -122,10 +122,38 @@ class Generator {
         */
         void GeneratePawnPseudoLegalMoves(const std::unique_ptr<Board> &board);
         /**
+         * @brief Generate en-passant moves.
+         * @param board The board configuration to generate moves for.
+        */
+        void GenerateEnPassantMoves(const std::unique_ptr<Board> &board);
+        /**
          * @brief Generate the set of possible castling moves.
          * @param board The board configuration to generate moves for.
         */
         void GenerateCastlingMoves(const std::unique_ptr<Board> &board);
+        /**
+         * @brief Get whether a specific type of castling is possible. Effectively checks occupancy and attack masks.
+         * @param castlingMask All squares that must be free from attack in order to permit castling (includes the king and end point and all squares in between).
+         * @param occupanyMask The tiles that must be free of any occupancy in order for castling to be permitted.
+         * @param board The board configuration to generate moves for.
+         * @return True if castling with these masks is possible.
+        */
+        bool IsCastlingPossible(U64 castlingMask, U64 occupancyMask, const std::unique_ptr<Board> &board);
+        /**
+         * @brief Get whether any squares in the specified mask are under attack from the enemy. Does not account for pinned enemy pieces.
+         * @param mask The mask of squares to check.
+         * @param attackingColor The colour to calculate the attack rays for.
+         * @param board The board configuration to generate moves for.
+         * @return True if any of the squares in mask are under attack from the specified colour.
+        */
+        bool IsUnderAttack(const U64 mask, const Color attackingColor, const std::unique_ptr<Board> &board);
+        /**
+         * @brief Get the bitboard of all possible attacks by the specified colour assuming they are the next colour to move. Does not take into account absolutely positioned pieces.
+         * @param board The board configuration to generate moves for.
+         * @param attackingColor The colour to calculate attacks for (assumes they are colour to move).
+         * @return Mask of all attacks by the attacking colour excluding absolute pins.
+        */
+        U64 GetAttacks(const std::unique_ptr<Board> &board, const Color attackingColor);
 
         // Attack tables generated on instantiation
         U64 fKnightAttacks[64]; ///< All possible attacks of a knight at each position on the board.

--- a/src/include/Generator.hpp
+++ b/src/include/Generator.hpp
@@ -1,0 +1,114 @@
+/**
+ * @file Generator.hpp
+ * @brief Definition of the Generator class.
+ */
+
+#ifndef GENERATOR_HPP
+#define GENERATOR_HPP
+
+#include <memory>
+#include <vector>
+#include <chrono>
+
+#include "Constants.hpp"
+#include "Board.hpp"
+#include "Move.hpp"
+
+/**
+ * @class Generator
+ * @brief Handles generation of legal moves.
+ * 
+ * The Generator class is used to handle the computation necessary to play the game with the user and all legal computer moves. The generator can check for move legality. It uses pre-generated attack tables to speed up computation.
+ */ 
+class Generator {
+    public:
+        /**
+         * @brief Instantiate a new instance of the Generator class.
+        */
+        explicit Generator();
+        /**
+         * @brief Generate all legal moves given a board configuration. Moves are stored in the fLegalMoves vector.
+         * @param board The board configuration for which legal moves will be generated.
+        */
+        void GenerateLegalMoves(const std::unique_ptr<Board> &board);
+        /**
+         * @brief Get the legal moves from the last move generation.
+         * @return Reference to the fLegalMoves vector.
+        */
+        std::vector<U32>& GetLegalMoves() { return fLegalMoves; };
+        /**
+         * @brief Get a copy of all the legal moves from the last move generation.
+         * @return Vector of all possible legal moves, as a copy of the fLegalMoves vector.
+        */
+        std::vector<U32> GetLegalMovesCopy() { return fLegalMoves; };
+    private:
+        std::vector<U32> fLegalMoves; ///< The set of legal moves available upon the last call to GenerateLegalMoves.
+
+        /**
+         * @brief Generate attack tables for faster lookup during move generation.
+        */
+        void GenerateAttackTables();
+        /**
+         * @brief Fill the king attack table for the position specified.
+         * @param pos The position of the king.
+        */
+        void FillKingAttackTable(const U64 pos);
+        /**
+         * @brief Fill the knight attack table for the position specified.
+         * @param pos The position of the knight.
+        */
+        void FillKnightAttackTable(const U64 pos);
+        /**
+         * @brief Fill the attack tables for white and black pawns.
+         * @param pos The position of the pawn.
+        */
+        void FillPawnAttackTable(const U64 pos);
+        /**
+         * @brief Fill attack table for straight sliding rays. Fills the primary (up-down) and secondary (side-to-side) straight attacks (e.g. those of a rook).
+         * @param pos The position of the sliding piece (rook/queen).
+        */
+        void FillStraightAttackTables(const U64 pos);
+        /**
+         * @brief Fill attack table for diagonal sliding rays. Fills the primary and secondary diagonal attacks (e.g. those of a bishop).
+         * @param pos The position of the sliding piece (bishop/queen).
+        */
+        void FillDiagonalAttackTables(const U64 pos);
+        /**
+         * @brief Check if the board has met the conditions for draw by the 50-move rule.
+         * @param board The board to check.
+         * @return True if the fifty move rule conditions have been met.
+        */
+        bool CheckFiftyMoveDraw(const std::unique_ptr<Board> &board);
+        /**
+         * @brief Check if the board has met the conditions for a draw by insufficient material.
+         * @param board The board to check.
+         * @return True if the conditions for insufficient material have been met.
+        */
+        bool CheckInsufficientMaterial(const std::unique_ptr<Board> &board);
+        /**
+         * @brief Generate the pseudo-legal moves for a given position and append to the fLegalMoves vector.
+         * @param board The board configuration to generate moves for.
+        */
+        void GeneratePseudoLegalMoves(const std::unique_ptr<Board> &board);
+
+        // Attack tables generated on instantiation
+        U64 fKnightAttacks[64]; ///< All possible attacks of a knight at each position on the board.
+        U64 fKingAttacks[64]; ///< All possible attacks of a king at each position on the board.
+        U64 fPrimaryDiagonalAttacks[64]; ///< Primary diagonal (bottom left to top right) attacks for a sliding diagonal piece at LSB.
+        U64 fSecondaryDiagonalAttacks[64]; ///< Secondary diagonal (top left to bottom right) attacks for a sliding diagonal piece at LSB.
+        U64 fPrimaryStraightAttacks[64]; ///< Primary straight attacks (rank) for a sliding straight piece at LSB.
+        U64 fSecondaryStraightAttacks[64]; ///< Primary straight attacks (file) for a sliding straight piece at LSB.
+        U64 fWhitePawnDiagonalAttacks[64]; ///< All possible diagonal attacks of a white pawn given LSB as input.
+        U64 fBlackPawnDiagonalAttacks[64]; ///< All possible diagonal attacks of a black pawn given LSB as input.
+        U64 fWhitePawnForwardAttacks[64]; ///< Attacks (1 and 2 square forwards) of the white pawns
+        U64 fBlackPawnForwardAttacks[64]; ///< Attacks (1 and 2 square forwards) of the black pawns
+
+        // Variables to use when generating moves, helps reduce number of function calls
+        Color fColor;
+        Color fOtherColor;
+        U64 fOccupancy;
+        U64 fKing;
+        
+};
+
+#endif

--- a/src/include/Generator.hpp
+++ b/src/include/Generator.hpp
@@ -159,6 +159,18 @@ class Generator {
          * @param board The board configuration to generate moves for.
         */
         void RemoveIllegalMoves(const std::unique_ptr<Board> &board);
+        /**
+         * @brief Fill a vetor with the position of all absolutely pinned pieces and the pinning ray they occupy.
+         * @param board The board configuration to generate moves for.
+         * @param v Vector to fill.
+         * @param d Direction to search for pinning rays.
+        */
+        void AddAbolsutePins(const std::unique_ptr<Board> &board, std::vector<std::pair<U64, U64>> *v, Direction d);
+        /**
+         * @brief Remove moves from the fLegalMoves vector that do not resolve the check when the king is in check.
+         * @param board The board configuration to generate moves for.
+        */
+        void PruneCheckMoves(const std::unique_ptr<Board> &board);
 
         // Attack tables generated on instantiation
         U64 fKnightAttacks[64]; ///< All possible attacks of a knight at each position on the board.

--- a/src/include/Test.hpp
+++ b/src/include/Test.hpp
@@ -38,7 +38,7 @@ class Test {
         /**
          * @brief Get the number of moves that are possible from the specified FEN position up to a specified depth.
         */
-        unsigned long int GetNodes(int depth, std::string fen);
+        unsigned long int GetNodes(int depth, std::string fen, bool doFinePrint);
         /**
          * @brief Get the board instance used for the testing
         */
@@ -53,6 +53,7 @@ class Test {
     private:
         bool fUseGUI; ///< If true display GUI to user when performing the tests
         int fPrintDepth;
+        bool fDoFinePrint; ///< Print out all moves at depth 1 during perft testing
         std::unique_ptr<Board> fBoard;
         std::unique_ptr<Engine> fEngine;
         std::unique_ptr<Generator> fGenerator;

--- a/src/include/Test.hpp
+++ b/src/include/Test.hpp
@@ -14,6 +14,7 @@
 #include "Move.hpp"
 #include "Renderer.hpp"
 #include "Engine.hpp"
+#include "Generator.hpp"
 #include "Board.hpp"
 
 /**
@@ -54,6 +55,7 @@ class Test {
         int fPrintDepth;
         std::unique_ptr<Board> fBoard;
         std::unique_ptr<Engine> fEngine;
+        std::unique_ptr<Generator> fGenerator;
         std::unique_ptr<Renderer> fGUI;
         std::vector<unsigned long int> fExpectedGeneration; ///< Total number of possible moves after each depth level
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,6 +12,7 @@ bool ProcessCommandLineArgs(const std::vector<std::string>& args,
                             bool &useGUI,
                             bool &doGame,
                             bool &helpRequested,
+                            bool &doFinePrint,
                             int &perftDepth,
                             int &playSelf,
                             Color &userColor,
@@ -22,6 +23,8 @@ bool ProcessCommandLineArgs(const std::vector<std::string>& args,
             useGUI = false;
         } else if(!arg.compare("--perft")) {
             perftDepth = std::stoi(args[i+1]); // TODO: Catch if this is not a valid digit
+        } else if(!arg.compare("--verbose")) {
+            doFinePrint = true; ///< Print all the moves generated when perft testing, useful for debugging
         } else if(!arg.compare("--help")) {
             helpRequested = true;
         } else if(!arg.compare("--fen")) {
@@ -231,25 +234,42 @@ int main(int argc, char* argv[]) {
     bool useGUI = true; 
     bool doGame = false;
     bool helpRequested = false;
+    bool doFinePrint = false;
     int perftDepth = 0;
     int playSelf = 0;
     Color userColor = Color::White;
     std::string fenString = "";
 
     std::vector<std::string> args(argv, argv + argc);
-    ProcessCommandLineArgs(args, useGUI, doGame, helpRequested, perftDepth, playSelf, userColor, fenString);
+    ProcessCommandLineArgs(args, useGUI, doGame, helpRequested, doFinePrint, perftDepth, playSelf, userColor, fenString);
 
     if(helpRequested) {
         DisplayHelp();
     } else if(perftDepth > 0) {
         Test myTest = Test(useGUI);
-        unsigned long int result = myTest.GetNodes(perftDepth, fenString);
+        unsigned long int result = myTest.GetNodes(perftDepth, fenString, doFinePrint);
         std::cout << "\nNodes searched: " << result << "\n";
     } else if(doGame) {
         Play(fenString, userColor);
     } else if(playSelf != 0) {
         PlaySelf(playSelf);
-    }
+    } else {
+        U64 rook = RANK_6 & FILE_H;
+        PrintBitset(rook);
 
+        U64 rook2 = RANK_8 & FILE_A;
+        //U64 attacks = RANK_4 | FILE_B;
+        //PrintBitset(attacks);
+
+        //U64 occ = (RANK_6 & FILE_B) | (RANK_1 & FILE_B) | (RANK_4 & FILE_E);
+        //PrintBitset(occ);
+        
+        // Get file of rook
+        int fileIndex = __builtin_ctzll(rook) / 8; // Assuming rookBitboard has exactly one bit set
+        std::cout << fileIndex << std::endl;
+
+        fileIndex = get_LSB(rook2) / 8;
+        std::cout << fileIndex << std::endl;
+    }
     return 0;
 }

--- a/src/src/Generator.cpp
+++ b/src/src/Generator.cpp
@@ -82,8 +82,7 @@ void Generator::GenerateLegalMoves(const std::unique_ptr<Board> &board) {
     GeneratePseudoLegalMoves(board);
     GenerateCastlingMoves(board);
     GenerateEnPassantMoves(board);
-    // UpdatePromotionMoves(moves);
-    // StripIllegalMoves(board, moves, otherColor, movingColor, movingKing);
+    RemoveIllegalMoves(board);
 
     if(fLegalMoves.size() == 0) { // No legal moves, game is either stalemate or checkmate
         bool kingInCheck = IsUnderAttack(fKing, fOtherColor, board);
@@ -234,8 +233,13 @@ void Generator::GeneratePawnPseudoLegalMoves(const std::unique_ptr<Board> &board
             const U64 attack = 1ULL << __builtin_ctzll(attacks);
             U32 move = 0;
             SetMove(move, pawn, attack, Piece::Pawn, board->GetIsOccupied(attack, fOtherColor).second);
-            if(attack & promotionRank)
+            if(attack & promotionRank) {
                 SetMoveIsPromotion(move, true);
+                for(Piece p : PROMOTION_PIECES) {
+                    SetMovePromotionPiece(move, p);
+                    fLegalMoves.push_back(move);
+                }
+            }
             fLegalMoves.push_back(move);
         }
         attacks = 0;
@@ -250,8 +254,13 @@ void Generator::GeneratePawnPseudoLegalMoves(const std::unique_ptr<Board> &board
             const U64 attack = 1ULL << __builtin_ctzll(attacks);
             U32 move = 0;
             SetMove(move, pawn, attack, Piece::Pawn, Piece::Null); // Forward moves don't take pieces
-            if(attack & promotionRank)
+            if(attack & promotionRank) {
                 SetMoveIsPromotion(move, true);
+                for(Piece p : PROMOTION_PIECES) {
+                    SetMovePromotionPiece(move, p);
+                    fLegalMoves.push_back(move);
+                }
+            }
             fLegalMoves.push_back(move);
         }
         pawns &= pawns - 1; // Drop the least significant bit
@@ -426,4 +435,8 @@ void Generator::GenerateEnPassantMoves(const std::unique_ptr<Board> &board) {
         fLegalMoves.push_back(move);
         enPassantPawns &= enPassantPawns - 1;
     }
+}
+
+void Generator::RemoveIllegalMoves(const std::unique_ptr<Board> &board) {
+
 }

--- a/src/src/Generator.cpp
+++ b/src/src/Generator.cpp
@@ -1,0 +1,128 @@
+#include "Generator.hpp"
+
+Generator::Generator() {
+    GenerateAttackTables();
+}
+
+void Generator::GenerateAttackTables() {
+    for(int iSquare = 0; iSquare < NSQUARES; ++iSquare) {
+        U64 position = 1ULL << iSquare;
+        FillKingAttackTable(position);
+        FillKnightAttackTable(position);
+        FillPawnAttackTable(position);
+        FillStraightAttackTables(position);
+        FillDiagonalAttackTables(position);
+    }
+}
+
+void Generator::FillKingAttackTable(const U64 pos) {
+    fKingAttacks[get_LSB(pos)] = north(pos) | east(pos) | west(pos) | south(pos) | north_east(pos) | north_west(pos) | south_east(pos) | south_west(pos);
+}
+
+void Generator::FillKnightAttackTable(const U64 pos) {
+    fKnightAttacks[get_LSB(pos)] = north(north_east(pos)) | north(north_west(pos)) | south(south_east(pos)) | south(south_west(pos)) | east(north_east(pos)) | east(south_east(pos)) | west(north_west(pos)) | west(south_west(pos));
+}
+
+void Generator::FillPawnAttackTable(const U64 pos) {
+    // Note this does not include special pawn moves like en-passant or promotion
+    U64 attacks = 0;
+    const U8 lsb = get_LSB(pos);
+    // White pawn case (attacks in a northern direction)
+    attacks |= north(pos);
+    if(pos & RANK_2)
+        attacks |= north(north(pos)); // Assumes nothing blocking the pawns path
+    fWhitePawnForwardAttacks[lsb] = attacks;
+    // Only valid when occupied by enemy piece as these are taking moves
+    fWhitePawnDiagonalAttacks[lsb] = north_east(pos) | north_west(pos);
+
+    attacks = 0; // Now case for the black pawn attacking in a southern direction
+    attacks |= south(pos);
+    if(pos & RANK_7)
+        attacks |= south(south(pos));
+    fBlackPawnForwardAttacks[lsb] = attacks;
+    fBlackPawnDiagonalAttacks[lsb] = south_east(pos) | south_west(pos);
+}
+
+void Generator::FillStraightAttackTables(const U64 pos) {
+    fPrimaryStraightAttacks[get_LSB(pos)] = get_rank(pos) ^ pos;
+    fSecondaryStraightAttacks[get_LSB(pos)] = get_file(pos) ^ pos;
+}
+
+void Generator::FillDiagonalAttackTables(const U64 pos) {
+    // Vertical distance from primary diagonal is just abs(x - y) (zero indexed)
+    // negative value = shift primary DOWN, positive value = shift primary UP
+    const U8 fileNumber = get_file_number(pos);
+    const U8 rankNumber = get_rank_number(pos);
+    const U8 lsb = get_LSB(pos);
+
+    const int dPrimaryDiag = (fileNumber - 1) - (8 - rankNumber); // Vertical distance from the primary diagonal
+    const int dSecondaryDiag = (8 - fileNumber) - (8 - rankNumber); // Vertical distance from the secondary diagonal
+
+    U64 primaryAttacks = dPrimaryDiag > 0 ? PRIMARY_DIAGONAL << (abs(dPrimaryDiag) * 8) : PRIMARY_DIAGONAL >> (abs(dPrimaryDiag) * 8);
+    U64 secondaryAttacks = dSecondaryDiag > 0 ? SECONDARY_DIAGONAL << (abs(dSecondaryDiag) * 8) : SECONDARY_DIAGONAL >> (abs(dSecondaryDiag) * 8);
+
+    fPrimaryDiagonalAttacks[lsb] = primaryAttacks ^ pos;
+    fSecondaryDiagonalAttacks[lsb] = secondaryAttacks ^ pos;
+}
+
+void Generator::GenerateLegalMoves(const std::unique_ptr<Board> &board) {
+    // TODO: implement me
+    // TODO: Make me multi-threaded?
+
+    if(CheckFiftyMoveDraw(board))
+        return;
+    if(CheckInsufficientMaterial(board))
+        return;
+
+    fColor = board->GetColorToMove();
+    fOtherColor = fColor == Color::White ? Color::Black : Color::White;
+    fOccupancy = board->GetOccupancy();
+    fKing = board->GetBoard(fColor, Piece::King);
+
+    GeneratePseudoLegalMoves(board);
+
+    // GeneratePseudoLegalMoves(board, moves, movingColor, otherColor, occ, movingKing);
+    // GenerateCastlingMoves(board, moves, movingColor, otherColor, movingKing, occ);
+    // GenerateEnPassantMoves(board, moves, movingColor);
+    // UpdatePromotionMoves(moves);
+    // StripIllegalMoves(board, moves, otherColor, movingColor, movingKing);
+
+    //if(moves.size() == 0) { // No legal moves, game is either stalemate or checkmate
+    //    bool kingInCheck = IsUnderAttack(movingKing, otherColor, board);
+    //    if(kingInCheck) {
+    //        board->SetState(State::Checkmate);
+    //    } else {
+    //        board->SetState(State::Stalemate);
+    //    }
+    //}
+}
+
+bool Generator::CheckFiftyMoveDraw(const std::unique_ptr<Board> &board) {
+    if(board->GetHalfMoveClock() == 100) {
+        board->SetState(State::FiftyMoveRule);
+        return true;
+    }   
+    return false;
+}
+
+bool Generator::CheckInsufficientMaterial(const std::unique_ptr<Board> &board) {
+    const U8 nBlackKnights = CountSetBits(board->GetBoard(Color::Black, Piece::Knight));
+    const U8 nBlackBishops = CountSetBits(board->GetBoard(Color::Black, Piece::Bishop));
+    const U8 nWhiteKnights = CountSetBits(board->GetBoard(Color::White, Piece::Knight));
+    const U8 nWhiteBishops = CountSetBits(board->GetBoard(Color::White, Piece::Bishop));
+    const U8 nBlackPieces = CountSetBits(board->GetBoard(Color::Black));
+    const U8 nWhitePieces = CountSetBits(board->GetBoard(Color::White));
+
+    if(nBlackPieces == 2 && (nBlackKnights == 1 || nBlackBishops == 1) && nWhitePieces == 1) {
+        board->SetState(State::InSufficientMaterial);
+        return true;
+    } else if(nWhitePieces == 2 && (nWhiteBishops == 1 || nWhiteKnights == 1) && nBlackPieces == 1) {
+        board->SetState(State::InSufficientMaterial);
+        return true;
+    }
+    return false;
+}
+
+void Generator::GeneratePseudoLegalMoves(const std::unique_ptr<Board> &board) {
+    // TODO: implement me
+}

--- a/src/src/Generator.cpp
+++ b/src/src/Generator.cpp
@@ -67,6 +67,7 @@ void Generator::FillDiagonalAttackTables(const U64 pos) {
 }
 
 void Generator::GenerateLegalMoves(const std::unique_ptr<Board> &board) {
+    fLegalMoves.clear();
     // TODO: Make me multi-threaded?
     if(CheckFiftyMoveDraw(board))
         return;
@@ -241,6 +242,7 @@ void Generator::GeneratePawnPseudoLegalMoves(const std::unique_ptr<Board> &board
                 }
             }
             fLegalMoves.push_back(move);
+            attacks &= attacks - 1;
         }
         attacks = 0;
 
@@ -262,6 +264,7 @@ void Generator::GeneratePawnPseudoLegalMoves(const std::unique_ptr<Board> &board
                 }
             }
             fLegalMoves.push_back(move);
+            attacks &= attacks - 1;
         }
         pawns &= pawns - 1; // Drop the least significant bit
     }

--- a/src/src/Generator.cpp
+++ b/src/src/Generator.cpp
@@ -412,7 +412,7 @@ void Generator::GenerateEnPassantMoves(const std::unique_ptr<Board> &board) {
     // Now run the usual code
     U32 lastMove = board->GetLastMove();
     U64 lastMoveTarget = GetMoveTarget(lastMove);
-    U64 lastMoveOrigin = GetMoveTarget(lastMove);
+    U64 lastMoveOrigin = GetMoveOrigin(lastMove);
 
     // Faster return if you know en-passant will not be possible
     if(GetMovePiece(lastMove) != Piece::Pawn || GetMoveIsEnPassant(lastMove) || GetMoveIsCastling(lastMove))

--- a/src/src/Test.cpp
+++ b/src/src/Test.cpp
@@ -5,6 +5,7 @@ Test::Test(bool useGUI) {
     fEngine = std::make_unique<Engine>(true);
     fGenerator = std::make_unique<Generator>();
     fUseGUI = useGUI;
+    fDoFinePrint = false;
     if(fUseGUI)
         fGUI = std::make_unique<Renderer>();
     fPrintDepth = 999;
@@ -23,7 +24,8 @@ Test::Test(bool useGUI) {
     };
 }
 
-unsigned long int Test::GetNodes(int depth, std::string fen) {
+unsigned long int Test::GetNodes(int depth, std::string fen, bool doFinePrint) {
+    fDoFinePrint = doFinePrint;
     auto start = std::chrono::high_resolution_clock::now(); // Time the execution
     if(fen.length() > 0)
         fBoard->LoadFEN(fen);
@@ -68,10 +70,10 @@ unsigned long int Test::MoveGeneration(int depth) {
             subPositions = numPositions;
         }
 
-        //if(depth == 1) {
-        //    std::cout << "\n depth 1 move = ";
-        //    PrintMove(move);
-        //}
+        if(depth == 1 && fDoFinePrint) {
+            std::cout << "\n depth 1 move = ";
+            PrintMove(move);
+        }
         fBoard->MakeMove(move);
         numPositions += MoveGeneration(depth - 1);
         if(depth == fPrintDepth) {

--- a/src/src/Test.cpp
+++ b/src/src/Test.cpp
@@ -3,6 +3,7 @@
 Test::Test(bool useGUI) {
     fBoard = std::make_unique<Board>();
     fEngine = std::make_unique<Engine>(true);
+    fGenerator = std::make_unique<Generator>();
     fUseGUI = useGUI;
     if(fUseGUI)
         fGUI = std::make_unique<Renderer>();
@@ -51,11 +52,12 @@ unsigned long int Test::MoveGeneration(int depth) {
     if(depth == 0)
         return 1;
 
-    fEngine->GenerateLegalMoves(fBoard);
+    fGenerator->GenerateLegalMoves(fBoard);
     unsigned long int numPositions = 0;
     unsigned long int subPositions = 0;
 
-    std::vector<U32> moves = fEngine->GetLegalMoves();
+    std::vector<U32> moves = fGenerator->GetLegalMoves(); // Puts moves inside this vector for you
+
     if(depth == fPrintDepth)
         std::cout << "Parent nodes searched: " << moves.size() << "\n";
 


### PR DESCRIPTION
Keep the code base cleaner by moving all move generation into a separate class. This way this single class can be heavily optimised and modified to improve move generation. The engine class may then solely focus on choosing the "best" moves.
