### PR TITLE
Add Zobrist Hashing Transposition Table

### DIFF
--- a/src/include/Board.hpp
+++ b/src/include/Board.hpp
@@ -205,7 +205,12 @@ class Board {
          * @brief Creates and prints the FEN of the current board to the console.
         */
         void PrintFEN() const;
+        /**
+         * @brief Calculates a semi-unique hash using the Zobrist keys previously generated for the current board state.
+        */
+        U64 GetHash();
     private:
+        ZobristKeys fKeys; ///< Struct to hold keys for Zobrist board hashing.
         U64 fBoards[12]; ///< Array of 12 bitboards defining the postion. White pieces occupy boards 0-5 and black 6-12 in order (pawn, knight, bishop, queen, king)
         int fUnique; ///< Integer that is incremented everytime the board is changed, undone or modified in any way.
         // Move tracking
@@ -230,6 +235,10 @@ class Board {
          * @brief Set all internal bitboards describing the chess board to zero (empty boards)
         */
         void EmptyBoards();
+        /**
+         * @brief Fill the arrays for the Zobrist key hashing. Randomly generates keys using a hardware generated seed.
+        */
+        void InitZobristKeys();
 };
 
 #endif

--- a/src/include/Constants.hpp
+++ b/src/include/Constants.hpp
@@ -429,7 +429,7 @@ constexpr int NUM_SQUARES = 64; // Number of squares on the board
 struct ZobristKeys {
     std::array<std::array<U64, NUM_PIECE_TYPES>, NUM_SQUARES> pieceKeys;
     std::array<U64, 2> sideToMoveKey;
-    std::array<U64, 8> castlingKeys; // Whether the player can or cannot castle. White = [0,3] black = [4,7]. Then goes kingside/queenside, yes/no e.g. WKY, WQY, WKN, WQN.
+    std::array<U64, 4> castlingKeys; // Whether the player can or cannot castle. White = [0,3] black = [4,7]. Then goes kingside/queenside, yes/no e.g. WKY, WQY, WKN, WQN.
     U64 enPassantKey;
 };
 

--- a/src/include/Constants.hpp
+++ b/src/include/Constants.hpp
@@ -3,6 +3,9 @@
 
 #include <iostream>
 #include <string>
+#include <cstdint>
+#include <array>
+#include <random>
 #include <vector>
 #include <bitset>
 
@@ -418,5 +421,22 @@ inline Piece GetPieceFromChar(char c) {
 }
 
 const std::vector<Piece> PIECES = {Piece::Pawn, Piece::Bishop, Piece::Knight, Piece::Rook, Piece::Queen, Piece::King}; ///< Vector of all the piece types for easy iterations
+
+// Zobrist hasing
+constexpr int NUM_PIECE_TYPES = 13; // Number of different piece types (including empty square)
+constexpr int NUM_SQUARES = 64; // Number of squares on the board
+
+struct ZobristKeys {
+    std::array<std::array<U64, NUM_PIECE_TYPES>, NUM_SQUARES> pieceKeys;
+    std::array<U64, 2> sideToMoveKey;
+    std::array<U64, 8> castlingKeys; // Whether the player can or cannot castle. White = [0,3] black = [4,7]. Then goes kingside/queenside, yes/no e.g. WKY, WQY, WKN, WQN.
+    U64 enPassantKey;
+};
+
+inline U64 GetRandomKey() {
+    static std::mt19937_64 rng(std::random_device{}());
+    static std::uniform_int_distribution<U64> dist;
+    return dist(rng);
+}
 
 #endif

--- a/src/include/Engine.hpp
+++ b/src/include/Engine.hpp
@@ -44,6 +44,7 @@ class Engine {
         int GetMaxDepth() { return fMaxDepth; };
         U32 GetBestMove(bool verbose);
     private:
+        int fNHashesFound;
         const std::unique_ptr<Generator> &fGenerator;
         const std::unique_ptr<Board> &fBoard;
         Color fOtherColor;

--- a/src/include/Engine.hpp
+++ b/src/include/Engine.hpp
@@ -11,6 +11,7 @@
 #include <vector>
 #include <cstdint>
 #include <chrono>
+#include <unordered_map>
 
 #include "Constants.hpp"
 #include "Board.hpp"
@@ -46,6 +47,7 @@ class Engine {
         const std::unique_ptr<Generator> &fGenerator;
         const std::unique_ptr<Board> &fBoard;
         Color fOtherColor;
+        std::unordered_map<U64, float> fEvaluationCache;
 
         float fKingPosModifier[2][64] = {{
             20, 30, 10,  0,  0, 10, 30, 20,

--- a/src/src/Board.cpp
+++ b/src/src/Board.cpp
@@ -3,7 +3,83 @@
 #include "Board.hpp"
 
 Board::Board() {
+    InitZobristKeys();
     Reset();
+}
+
+void Board::InitZobristKeys() {
+    for (int i = 0; i < NUM_SQUARES; ++i) {
+        for(int j = 0; j < NUM_PIECE_TYPES; ++j) {
+            fKeys.pieceKeys[i][j] = GetRandomKey();
+        }
+    }
+    fKeys.sideToMoveKey[0] = GetRandomKey(); // White to move
+    fKeys.sideToMoveKey[1] = GetRandomKey(); // Black to move
+    for(int i = 0; i < 8; ++i) {
+        fKeys.castlingKeys[i] = GetRandomKey();
+    }
+    fKeys.enPassantKey = GetRandomKey();
+}
+
+U64 Board::GetHash() {
+    U64 hash = 0;
+
+    // Piece placement
+    for(U64 rank : RANKS) {
+        for(U64 file : FILES) {
+            U64 square = rank & file;
+            std::pair<Color, Piece> occupation = GetIsOccupied(square);
+
+            if(occupation.second != Piece::Null) {
+                // Piece is in range [1,6], then add zero for white or 6 for black
+                hash ^= fKeys.pieceKeys[get_LSB(square)][(int)occupation.second + (occupation.first == Color::White ? 0 : 6)];
+            }
+        }
+    }
+    // Side to move
+    hash ^= fKeys.sideToMoveKey[(int)fColorToMove];
+    // Castling rights
+    bool wKingside = fWhiteKingsideRookMoved == 0;
+    bool bKingside = fBlackKingsideRookMoved == 0;
+    bool wQueenside = fWhiteQueensideRookMoved == 0;
+    bool bQueenside = fBlackQueensideRookMoved == 0;
+    if(fWhiteKingMoved == 0) {
+        if(wKingside) {
+            hash ^= fKeys.castlingKeys[0];
+        } else {
+            hash ^= fKeys.castlingKeys[2];
+        }
+        if(wQueenside) {
+            hash ^= fKeys.castlingKeys[1];
+        } else {
+            hash ^= fKeys.castlingKeys[3];
+        }
+    } else { // No castling rights
+        hash ^= fKeys.castlingKeys[2];
+        hash ^= fKeys.castlingKeys[3];
+    }
+    if(fBlackKingMoved == 0) { // No castling rights
+        if(bKingside) {
+            hash ^= fKeys.castlingKeys[4];
+        } else {
+            hash ^= fKeys.castlingKeys[6];
+        }
+        if(bQueenside) {
+            hash ^= fKeys.castlingKeys[5];
+        } else {
+            hash ^= fKeys.castlingKeys[7];
+        }
+    } else {
+        hash ^= fKeys.castlingKeys[6];
+        hash ^= fKeys.castlingKeys[7];
+    }
+
+    // En passant square
+    //if (enPassantSquare != -1) {
+    //    hash ^= zobristKeys.enPassantKey;
+    //}
+
+    return hash;
 }
 
 Board::Board(const Board& other) {

--- a/src/src/Engine.cpp
+++ b/src/src/Engine.cpp
@@ -5,16 +5,25 @@
 #include "Engine.hpp"
 
 Engine::Engine(const std::unique_ptr<Generator> &generator, const std::unique_ptr<Board> &board, const int maxDepth) : fGenerator(generator), fBoard(board), fMaxDepth(maxDepth) {
-
+    fEvaluationCache.clear();
 }
 
 
 float Engine::Evaluate() {
+    // See if we have evaluated this board before (via a transposition)
+    // Hash not perfectly unique but "unique" enough, extremely unlikely to cause problems
+    U64 thisHash = fBoard->GetHash();
+    int perspective = fBoard->GetColorToMove() == Color::White ? 1. : -1.;
+
+    auto it = fEvaluationCache.find(thisHash);
+    if(it != fEvaluationCache.end()) {
+        return it->second * perspective;
+    }
+
     fOtherColor = fBoard->GetColorToMove() == Color::White ? Color::Black : Color::White;
     float evaluation = GetMaterialEvaluation();
-
     //evaluation += ForceKingToCornerEndgame();
-    int perspective = fBoard->GetColorToMove() == Color::White ? 1. : -1.;
+    fEvaluationCache[thisHash] = evaluation;
     return evaluation * perspective; // Return in centipawns rather than pawns
 }
 

--- a/src/src/Engine.cpp
+++ b/src/src/Engine.cpp
@@ -17,6 +17,7 @@ float Engine::Evaluate() {
 
     auto it = fEvaluationCache.find(thisHash);
     if(it != fEvaluationCache.end()) {
+        fNHashesFound++;
         return it->second * perspective;
     }
 
@@ -231,6 +232,7 @@ std::pair<float, int> Engine::Minimax(int depth, float alpha, float beta) {
 }
 
 U32 Engine::GetBestMove(bool verbose) {
+    fNHashesFound = 0;
     auto start = std::chrono::high_resolution_clock::now();
     U32 bestMove{0};
     Color colorToMove = fBoard->GetColorToMove();
@@ -263,7 +265,7 @@ U32 Engine::GetBestMove(bool verbose) {
     auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(stop - start);
     if(verbose) {
         std::cout << "Time: " << duration.count() / 1000. << " seconds\n";
-        std::cout << "Evaluated: " << nMovesSearched << " positions\n";
+        std::cout << "Evaluated: " << nMovesSearched << " positions (" << fNHashesFound << " hashes used)\n";
     }
     return bestMove;
 }


### PR DESCRIPTION
Add a basic implementation of the Zobrist hashing mechanism to make non-unique (but unique enough likely for our purposes) hash for each chess board. Use this hash table to lookup evaluations (same positions yielded by transpositions i.e. different move orders). Should speed up the evaluation function significantly as its complexity grows.